### PR TITLE
Fix condition to check whether a argument is number or not

### DIFF
--- a/jquery.serialScroll.js
+++ b/jquery.serialScroll.js
@@ -150,7 +150,7 @@
 			};
 
 			function jump( e, pos ){
-				if( isNaN(pos) )
+				if( !$.isNumeric(pos) )
 					pos = e.data;
 
 				var	n, 


### PR DESCRIPTION
Looks like this condition is meant to test whether `pos` is numeric or not, so it'll work properly for cases like `jump` function is called after clicking navigation elements.

``` javascript
                nav = $(nav, context).bind(event, function( e ){
                    e.data = Math.round(getItems().length / nav.length) * nav.index(this);
                    jump( e, this );
                });
```

`isNaN(x)` doesn't seem appropriate for this purpose as it returns false when `x` can be typecasted to a number, and in fact when a DOM element is passed like this case (at least with the latest Chrome).

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/isNaN 

(P.S. Thanks for the nice jQuery plugin!)
