### PR TITLE
Prevents jumping to the end on a click where e.data isn't a number

### DIFF
--- a/jquery.serialScroll.js
+++ b/jquery.serialScroll.js
@@ -152,7 +152,10 @@
 			function jump( e, pos ){
 				if( isNaN(pos) )
 					pos = e.data;
-
+				// jump should ignore events where e.data (pos) isn't a number
+				if( typeof pos !== "number" )
+					return;
+				
 				var	n, 
 					// Is a real event triggering ?
 					real = e.type, 


### PR DESCRIPTION
Handles the case when the click is on an element within an item, such that e.data is an object instead of an array position. In this case, jump should do nothing.

By the way, I really love all of your scrollTo stuff. It is everything that I was looking for. Thanks for decoupling everything really nicely, I've been able to achieve something really cool with this.
