### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install jquery.serialscroll
 
 CDN provided by [jsdelivr](http://www.jsdelivr.com/#!jquery.serialscroll)
 ```html
-<script src="//cdn.jsdelivr.net/jquery.serialscroll/1.3.0/jquery.serialScroll.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/jquery.serialscroll@1.3.0/jquery.serialScroll.min.js"></script>
 ```
 
 ### Downloading Manually


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.serialscroll.

Feel free to ping me if you have any questions regarding this change.